### PR TITLE
spi flash write operations

### DIFF
--- a/hw/xtensa/esp8266.c
+++ b/hw/xtensa/esp8266.c
@@ -41,7 +41,7 @@
 #include "qemu/error-report.h"
 #include "bootparam.h"
 
-#define DEBUG_LOG(...) fprintf(stderr, __VA_ARGS__)
+#define DEBUG_LOG(...) // fprintf(stderr, __VA_ARGS__)
 
 #define DEFINE_BITS(prefix, reg, field, shift, len) \
     prefix##_##reg##_##field##_SHIFT = shift, \
@@ -372,6 +372,10 @@ enum {
 
 enum {
     ESP8266_SPI_FLASH_BITS(CMD, USR, 18, 1),
+    ESP8266_SPI_FLASH_BITS(CMD, CE, 22, 1),
+    ESP8266_SPI_FLASH_BITS(CMD, BE, 23, 1),
+    ESP8266_SPI_FLASH_BITS(CMD, SE, 24, 1),
+    ESP8266_SPI_FLASH_BITS(CMD, PP, 25, 1),
     ESP8266_SPI_FLASH_BITS(CMD, WRDI, 29, 1),
     ESP8266_SPI_FLASH_BITS(CMD, WREN, 30, 1),
     ESP8266_SPI_FLASH_BITS(CMD, READ, 31, 1),
@@ -422,12 +426,19 @@ static uint64_t esp8266_spi_read(void *opaque, hwaddr addr, unsigned size)
     Esp8266SpiState *s = opaque;
 
     DEBUG_LOG("%s: +0x%02x: ", __func__, (uint32_t)addr);
-    if (addr / 4 >= ESP8266_SPI_MAX || addr % 4 || size != 4) {
+    if (addr / 4 >= ESP8266_SPI_MAX || addr % 4 || size > 4) {
         DEBUG_LOG("0\n");
         return 0;
     }
-    DEBUG_LOG("0x%08x\n", s->reg[addr / 4]);
-    return s->reg[addr / 4];
+    else if (size == 4) {
+        DEBUG_LOG("0x%08x\n", s->reg[addr / 4]);
+        return s->reg[addr / 4];
+    }
+
+    uint32_t ret = 0;
+    memcpy(&ret, s->reg + ESP8266_SPI_FLASH_C0, size);
+    DEBUG_LOG("0x%08x\n", ret);
+    return ret;
 }
 
 static void esp8266_spi_cmd(Esp8266SpiState *s, hwaddr addr,
@@ -457,6 +468,32 @@ static void esp8266_spi_cmd(Esp8266SpiState *s, hwaddr addr,
                   __func__,
                   ESP8266_SPI_GET(s, USER2, COMMAND_VALUE),
                   ESP8266_SPI_GET(s, USER2, COMMAND_BITLEN));
+    }
+    if (val & ESP8266_SPI_FLASH_CMD_SE) {
+        DEBUG_LOG("%s: SECTOR ERASE @0x%08x\n",
+                  __func__,
+                  ESP8266_SPI_GET(s, ADDR, OFFSET) & 0xfff);
+        memset(s->flash_image + (ESP8266_SPI_GET(s, ADDR, OFFSET) & ~0xfff), 0xff, 4096);
+    }
+    if (val & ESP8266_SPI_FLASH_CMD_BE) {
+        DEBUG_LOG("%s: BLOCK ERASE @0x%08x\n",
+                  __func__,
+                  ESP8266_SPI_GET(s, ADDR, OFFSET) & 0xffff);
+        memset(s->flash_image + (ESP8266_SPI_GET(s, ADDR, OFFSET) & ~0xffff), 0xff, 65536);
+    }
+    if (val & ESP8266_SPI_FLASH_CMD_BE) {
+        DEBUG_LOG("%s: CHIP ERASE\n",
+                  __func__);
+        memset(s->flash_image, 0xff, ESP8266_MAX_FLASH_SZ);
+    }
+    if (val & ESP8266_SPI_FLASH_CMD_PP) {
+        DEBUG_LOG("%s: WRITE FLASH 0x%02x@0x%08x\n",
+                  __func__,
+                  ESP8266_SPI_GET(s, ADDR, LENGTH),
+                  ESP8266_SPI_GET(s, ADDR, OFFSET));
+        memcpy(s->flash_image + ESP8266_SPI_GET(s, ADDR, OFFSET),
+               s->reg + ESP8266_SPI_FLASH_C0,
+               (ESP8266_SPI_GET(s, ADDR, LENGTH) + 3) & 0x3c);
     }
 }
 

--- a/hw/xtensa/esp8266.c
+++ b/hw/xtensa/esp8266.c
@@ -41,7 +41,7 @@
 #include "qemu/error-report.h"
 #include "bootparam.h"
 
-#define DEBUG_LOG(...) // fprintf(stderr, __VA_ARGS__)
+#define DEBUG_LOG(...) fprintf(stderr, __VA_ARGS__)
 
 #define DEFINE_BITS(prefix, reg, field, shift, len) \
     prefix##_##reg##_##field##_SHIFT = shift, \
@@ -436,7 +436,7 @@ static uint64_t esp8266_spi_read(void *opaque, hwaddr addr, unsigned size)
     }
 
     uint32_t ret = 0;
-    memcpy(&ret, s->reg + ESP8266_SPI_FLASH_C0, size);
+    memcpy(&ret, &s->reg[addr / 4], size);
     DEBUG_LOG("0x%08x\n", ret);
     return ret;
 }
@@ -481,7 +481,7 @@ static void esp8266_spi_cmd(Esp8266SpiState *s, hwaddr addr,
                   ESP8266_SPI_GET(s, ADDR, OFFSET) & 0xffff);
         memset(s->flash_image + (ESP8266_SPI_GET(s, ADDR, OFFSET) & ~0xffff), 0xff, 65536);
     }
-    if (val & ESP8266_SPI_FLASH_CMD_BE) {
+    if (val & ESP8266_SPI_FLASH_CMD_CE) {
         DEBUG_LOG("%s: CHIP ERASE\n",
                   __func__);
         memset(s->flash_image, 0xff, ESP8266_MAX_FLASH_SZ);


### PR DESCRIPTION
Implements SPI erase commands (sector, block and chip) as well as SPI flash write command. 

It is now possible to write to the flash image in memory. This became necessary for images built with the NON-OS SDK version 2.1.0. This SDK version uses the ```wifi_param_save_protect_with_check``` function at startup to write a WiFi configuration to the flash, if none exists. After that, it compares the written configuration with the configuration read from flash to check whether the configuration has been written successfully. If the comparision fails, it repeats this procedure endless.

With the implementation it is now also possible to use file systems like spifss in the emulation.
